### PR TITLE
Enable preprocessor blocks

### DIFF
--- a/lib/nxt_init/version.rb
+++ b/lib/nxt_init/version.rb
@@ -1,3 +1,3 @@
 module NxtInit
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/nxt_init_spec.rb
+++ b/spec/nxt_init_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe NxtInit do
         expect(subject.send(:plain)).to eq('plain')
         expect(subject.send(:with_default_value)).to eq('default')
         expect(subject.send(:with_default_block)).to eq('default block')
-        expect(subject.send(:with_default_block)).to eq('default block')
       end
     end
 


### PR DESCRIPTION
Now you can also use blocks as preprocessors when passing an argument:

```
Preprocessor
  include NxtInit
  attr_init date: -> (attr) { Date.parse(attr) }
end

Preprocessor.new(date: '25.02.1984')
Preprocessor.new(date: nil) # nil passed to block
Preprocessor.new # KeyError
```

